### PR TITLE
Make examples in '02_Containers.md' executable

### DIFF
--- a/Notes/02_Working_with_data/02_Containers.md
+++ b/Notes/02_Working_with_data/02_Containers.md
@@ -52,9 +52,10 @@ An example when reading records from a file.
 records = []  # Initial empty list
 
 with open('Data/portfolio.csv', 'rt') as f:
+    next(f) # Skip header
     for line in f:
         row = line.split(',')
-        records.append((row[0], int(row[1])), float(row[2]))
+        records.append((row[0], int(row[1]), float(row[2])))
 ```
 
 ### Dicts as a Container


### PR DESCRIPTION
This PR makes example of list construction when reading from a file executable.

There is also an issue with ["Dict Construction" from file example](https://github.com/dabeaz-course/practical-python/blob/master/Notes/02_Working_with_data/02_Containers.md#dict-construction). It gives an error because 'Data/prices.csv' file has an empty last row. I'd make a change to account for that but not sure if this clutters example clarity too much:

```python
prices = {} # Initial empty dict

with open('Data/prices.csv', 'rt') as f:
    for line in f:
        row = line.split(',')
        if len(row) >= 2: # Ensure enough data in a row
            prices[row[0]] = float(row[1])
```

If this change is desirable, I'll update this PR.