### PR TITLE
Fix syntax for inspecting imported numpy package

### DIFF
--- a/Notes/09_Packages/02_Third_party.md
+++ b/Notes/09_Packages/02_Third_party.md
@@ -50,6 +50,7 @@ the same steps as above:
 
 ```python
 >>> import numpy
+>>> numpy
 <module 'numpy' from '/usr/local/lib/python3.6/site-packages/numpy/__init__.py'>
 >>>
 ```


### PR DESCRIPTION
Like the `re` example, we have to enter the module name in order to inspect it.