### PR TITLE
Output correct types in example in Notes/03_Program_organization/02_More_functions.md

### DIFF
--- a/Notes/03_Program_organization/02_More_functions.md
+++ b/Notes/03_Program_organization/02_More_functions.md
@@ -501,7 +501,7 @@ For example:
 ```python
 >>> portfolio = parse_csv('Data/portfolio.dat', types=[str, int, float], delimiter=' ')
 >>> portfolio
-[{'price': '32.20', 'name': 'AA', 'shares': '100'}, {'price': '91.10', 'name': 'IBM', 'shares': '50'}, {'price': '83.44', 'name': 'CAT', 'shares': '150'}, {'price': '51.23', 'name': 'MSFT', 'shares': '200'}, {'price': '40.37', 'name': 'GE', 'shares': '95'}, {'price': '65.10', 'name': 'MSFT', 'shares': '50'}, {'price': '70.44', 'name': 'IBM', 'shares': '100'}]
+[{'name': 'AA', 'shares': 100, 'price': 32.2}, {'name': 'IBM', 'shares': 50, 'price': 91.1}, {'name': 'CAT', 'shares': 150, 'price': 83.44}, {'name': 'MSFT', 'shares': 200, 'price': 51.23}, {'name': 'GE', 'shares': 95, 'price': 40.37}, {'name': 'MSFT', 'shares': 50, 'price': 65.1}, {'name': 'IBM', 'shares': 100, 'price': 70.44}]
 >>>
 ```
 


### PR DESCRIPTION
Since we're passing in `types=[str, int, float]`:
- the output keys should be in the order `name`, `shares`, `price`
- the output for `shares` and `price` should be of type `int` and `float`